### PR TITLE
Add `const` to keyword matcher

### DIFF
--- a/src/svelte.js
+++ b/src/svelte.js
@@ -44,7 +44,7 @@ export function hljsDefineSvelte(hljs) {
             skip: true
           },
           {
-            begin: /([#:\/@])(if|else|each|await|then|catch|debug|html)/gm,
+            begin: /([#:\/@])(if|else|each|await|then|catch|debug|html|const)/gm,
             className:'keyword',
             relevance: 10,
           }


### PR DESCRIPTION
[`@const`](https://svelte.dev/docs#template-syntax-const) is supported in Svelte version 3.46